### PR TITLE
feat: Add content retrieval, search, ranking, caching function, redis

### DIFF
--- a/src/main/java/com/example/com/netplus/dto/content/response/ContentResponse.java
+++ b/src/main/java/com/example/com/netplus/dto/content/response/ContentResponse.java
@@ -1,6 +1,7 @@
 package com.example.com.netplus.dto.content.response;
 
 import com.example.com.netplus.common.Category;
+import com.example.com.netplus.entity.Content;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,11 @@ public class ContentResponse {
     private String title;
     private String description;
     private Category category;
+
+    public ContentResponse(Content content, int viewCount) {
+        this.contentId = content.getContentId();
+        this.title = content.getTitle();
+        this.description = content.getDescription();
+        this.category = content.getCategory();
+    }
 }

--- a/src/main/java/com/example/com/netplus/dto/content/response/ContentWithViewCountResponse.java
+++ b/src/main/java/com/example/com/netplus/dto/content/response/ContentWithViewCountResponse.java
@@ -1,0 +1,11 @@
+package com.example.com.netplus.dto.content.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContentWithViewCountResponse {
+    private final ContentResponse content;
+    private final int viewCount;
+}

--- a/src/main/java/com/example/com/netplus/repository/ContentRepository.java
+++ b/src/main/java/com/example/com/netplus/repository/ContentRepository.java
@@ -16,5 +16,5 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
      * @param pageable 페이징 정보
      * @return 페이징 처리된 Content 엔티티 목록
      */
-    Page<Content> findAll(Pageable pageable);
+    Page<Content> findByTitleContainingIgnoreCase(String title, Pageable pageable);
 }

--- a/src/main/java/com/example/com/netplus/service/RankingService.java
+++ b/src/main/java/com/example/com/netplus/service/RankingService.java
@@ -1,0 +1,75 @@
+package com.example.com.netplus.service;
+
+import com.example.com.netplus.dto.content.response.ContentResponse;
+import com.example.com.netplus.entity.Content;
+import com.example.com.netplus.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ContentRepository contentRepository;
+
+    private static final String RANKING_KEY_PREFIX = "ranking:";
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    public void updateRanking() {
+        // 자정에 랭킹을 업데이트하여 최신 조회수 기준으로 컨텐츠 랭킹을 저장
+        String key = RANKING_KEY_PREFIX + LocalDate.now();
+        redisTemplate.delete(key);
+
+        Set<String> contentKeys = redisTemplate.keys("content:view:*");
+        if (contentKeys == null || contentKeys.isEmpty()) return;
+
+        // 각 컨텐츠의 조회수를 확인하고, 랭킹에 추가
+        for (String contentKey : contentKeys) {
+            Long contentId = Long.parseLong(contentKey.replace("content:view:", ""));
+            Integer viewCount = Optional.ofNullable(redisTemplate.opsForValue().get(contentKey))
+                    .map(Object::toString)
+                    .map(Integer::valueOf)
+                    .orElse(0);
+
+            if (viewCount > 0) { // 조회수가 0 초과일 때만 랭킹에 추가
+                redisTemplate.opsForZSet().add(key, contentId.toString(), viewCount);
+            }
+        }
+
+        // 상위 10개 유지
+        redisTemplate.opsForZSet().removeRange(key, 10, -1);
+    }
+
+    @Cacheable(value = "topContents", key = "#date")
+    public List<ContentResponse> getTopContents(LocalDate date) {
+        // 날짜별 인기 컨텐츠 조회, Redis에서 랭킹을 가져옴
+        String key = RANKING_KEY_PREFIX + date;
+        Set<String> topContentIds = redisTemplate.opsForZSet().reverseRange(key, 0, 9);
+        if (topContentIds == null || topContentIds.isEmpty()) return List.of();
+
+        List<Long> contentIds = topContentIds.stream().map(Long::parseLong).collect(Collectors.toList());
+        List<Content> contents = contentRepository.findAllById(contentIds);
+
+        // 조회수를 포함한 컨텐츠 목록 반환
+        return contents.stream()
+                .map(content -> new ContentResponse(content, getViewCount(content.getContentId())))
+                .collect(Collectors.toList());
+    }
+
+    private int getViewCount(Long contentId) {
+        // 조회수를 Redis에서 가져옴
+        return Optional.ofNullable(redisTemplate.opsForValue().get("content:view:" + contentId))
+                .map(Object::toString)
+                .map(Integer::valueOf)
+                .orElse(0);
+    }
+}


### PR DESCRIPTION
컨텐츠 조회, 검색, 인기 컨텐츠 랭킹, 조회수 증가 및 캐싱 기능 추가
컨텐츠와 함께 조회수를 반환, 조회수는 redis에 캐시되어 성능 최적화
매일 자정마다 인기 컨텐츠 랭킹이 갱신, 조회수를 기반으로 순위가 바뀜
조회수 관리는 redis를 사용해 조회수를 캐시하고 새로운 사용자가 조회할 때마다 증가하고, 동일인에 관해서는 조회수 중복 증가 않도록 함