### PR TITLE
fix: Add constructor ContentResponse and RedisConfig

### DIFF
--- a/src/main/java/com/example/com/netplus/config/RedisConfig.java
+++ b/src/main/java/com/example/com/netplus/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package com.example.com.netplus.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Integer> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/example/com/netplus/dto/content/response/ContentResponse.java
+++ b/src/main/java/com/example/com/netplus/dto/content/response/ContentResponse.java
@@ -19,4 +19,11 @@ public class ContentResponse {
         this.description = content.getDescription();
         this.category = content.getCategory();
     }
+    
+    public ContentResponse(Long contentId, String title, String description, Category category) {
+        this.contentId = contentId;
+        this.title = title;
+        this.description = description;
+        this.category = category;
+    }
 }


### PR DESCRIPTION
ContentResponse에 필요한 생성자를 추가하고 객체 생성시 필요한 필드 값을 전달할 수 있도록 수정 RedisConfig 클래스를 생성해 RedisTemplate<String, Integer> 빈 등록